### PR TITLE
feat: harden passkeys implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.facebook.react:react-native:+'
+  implementation 'com.facebook.react:react-native'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
   implementation "androidx.credentials:credentials:1.3.0-rc01"

--- a/ios/PasskeyDelegate.swift
+++ b/ios/PasskeyDelegate.swift
@@ -43,6 +43,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate,
         case let credential as ASAuthorizationPlatformPublicKeyCredentialRegistration:
             if credential.rawAttestationObject == nil {
                 handler.onFailure((ASAuthorizationError(ASAuthorizationError.Code.failed)))
+                return
             }
 
             var largeBlob: AuthenticationExtensionsLargeBlobOutputsJSON?
@@ -86,6 +87,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate,
         case let credential as ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:
             if credential.rawAttestationObject == nil {
                 handler.onFailure((ASAuthorizationError(ASAuthorizationError.Code.failed)))
+                return
             }
 
             let response = AuthenticatorAttestationResponseJSON(
@@ -162,6 +164,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate,
             handler.onSuccess(.authentication(assertionResult))
         default:
             handler.onFailure((ASAuthorizationError(ASAuthorizationError.Code.failed)))
+            return
         }
     }
 }

--- a/ios/PasskeyExceptions.swift
+++ b/ios/PasskeyExceptions.swift
@@ -9,6 +9,10 @@ enum AppError: Error {
   case invalidChallengeException
   case missingUserIdException
   case invalidUserIdException
+  case missingRelyingPartyIdException
+  case invalidPrfFirstValueException
+  case invalidPrfSecondValueException
+  case invalidLargeBlobDataException
   case passkeyRequestFailedException(Error)
   case passkeyAuthorizationFailedException(Error)
   case genericError(String)
@@ -33,6 +37,14 @@ extension AppError: LocalizedError {
         return "`userId` is required"
       case .invalidUserIdException:
         return "The provided userId was invalid"
+      case .missingRelyingPartyIdException:
+        return "Missing relying party ID"
+      case .invalidPrfFirstValueException:
+        return "Invalid base64URL encoded PRF first value"
+      case .invalidPrfSecondValueException:
+        return "Invalid base64URL encoded PRF second value"
+      case .invalidLargeBlobDataException:
+        return "Invalid base64URL encoded large blob data"
       case .passkeyRequestFailedException(let originalError):
         return "The passkey request failed: \(originalError.localizedDescription)"
       case .passkeyAuthorizationFailedException(let originalError):

--- a/ios/ReactNativePasskeys.swift
+++ b/ios/ReactNativePasskeys.swift
@@ -88,11 +88,11 @@ class ReactNativePasskeys: NSObject, PasskeyResultHandler {
       var platformKeyRegistrationRequest: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest?
 
       if creationOptions.authenticatorSelection?.authenticatorAttachment == AuthenticatorAttachment.crossPlatform {
-        crossPlatformKeyRegistrationRequest = prepareCrossPlatformRegistrationRequest(challenge: challengeData,
+        crossPlatformKeyRegistrationRequest = try prepareCrossPlatformRegistrationRequest(challenge: challengeData,
                                                                                       userId: userId,
                                                                                       request: creationOptions)
       } else {
-        platformKeyRegistrationRequest = preparePlatformRegistrationRequest(challenge: challengeData,
+        platformKeyRegistrationRequest = try preparePlatformRegistrationRequest(challenge: challengeData,
                                                                             userId: userId,
                                                                             request: creationOptions)
       }
@@ -184,7 +184,7 @@ class ReactNativePasskeys: NSObject, PasskeyResultHandler {
       }
 
       let crossPlatformKeyAssertionRequest = prepareCrossPlatformAssertionRequest(challenge: challengeData, request: requestOptions)
-      let platformKeyAssertionRequest = preparePlatformAssertionRequest(challenge: challengeData, request: requestOptions)
+      let platformKeyAssertionRequest = try preparePlatformAssertionRequest(challenge: challengeData, request: requestOptions)
 
       let authController = ASAuthorizationController(authorizationRequests: [platformKeyAssertionRequest, crossPlatformKeyAssertionRequest])
 
@@ -202,9 +202,13 @@ class ReactNativePasskeys: NSObject, PasskeyResultHandler {
 
 private func preparePlatformRegistrationRequest(challenge: Data,
                                                 userId: Data,
-                                                request: PublicKeyCredentialCreationOptions) -> ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest {
+                                                request: PublicKeyCredentialCreationOptions) throws -> ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest {
+  guard let rpId = request.rp.id else {
+    throw AppError.missingRelyingPartyIdException
+  }
+  
   let platformKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-    relyingPartyIdentifier: request.rp.id!)
+    relyingPartyIdentifier: rpId)
 
   let platformKeyRegistrationRequest =
   platformKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge,
@@ -231,9 +235,16 @@ private func preparePlatformRegistrationRequest(challenge: Data,
   
   if #available(iOS 18, *) {
     if let prf = request.extensions?.prf {
-      platformKeyRegistrationRequest.prf = prf.eval.map { eval in
-        let first = Data(base64URLEncoded: eval.first)!
-        let second = eval.second.flatMap { Data(base64URLEncoded: $0) }
+      platformKeyRegistrationRequest.prf = try prf.eval.map { eval in
+        guard let first = Data(base64URLEncoded: eval.first) else {
+          throw AppError.invalidPrfFirstValueException
+        }
+        let second = try eval.second.map { secondValue in
+          guard let decoded = Data(base64URLEncoded: secondValue) else {
+            throw AppError.invalidPrfSecondValueException
+          }
+          return decoded
+        }
         return .inputValues(ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: first, saltInput2: second))
       } ?? .checkForSupport
     }
@@ -261,9 +272,12 @@ private func preparePlatformRegistrationRequest(challenge: Data,
 
 private func prepareCrossPlatformRegistrationRequest(challenge: Data,
                                                      userId: Data,
-                                                     request: PublicKeyCredentialCreationOptions) -> ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequest {
+                                                     request: PublicKeyCredentialCreationOptions) throws -> ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequest {
+  guard let rpId = request.rp.id else {
+    throw AppError.missingRelyingPartyIdException
+  }
 
-  let crossPlatformCredentialProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: request.rp.id!)
+  let crossPlatformCredentialProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
 
 
   let crossPlatformRegistrationRequest =
@@ -318,7 +332,7 @@ private func prepareCrossPlatformAssertionRequest(challenge: Data,
   return crossPlatformAssertionRequest
 }
 
-private func preparePlatformAssertionRequest(challenge: Data, request: PublicKeyCredentialRequestOptions) -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
+private func preparePlatformAssertionRequest(challenge: Data, request: PublicKeyCredentialRequestOptions) throws -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
 
   let platformKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(
     relyingPartyIdentifier: request.rpId)
@@ -334,17 +348,25 @@ private func preparePlatformAssertionRequest(challenge: Data, request: PublicKey
     }
 
     else if let blob = request.extensions?.largeBlob?.write {
-      platformKeyAssertionRequest.largeBlob = ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput.write(
-        Data(base64URLEncoded: blob)!
-      )
+      guard let blobData = Data(base64URLEncoded: blob) else {
+        throw AppError.invalidLargeBlobDataException
+      }
+      platformKeyAssertionRequest.largeBlob = ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput.write(blobData)
     }
   }
      
     
   if #available(iOS 18, *) {
-      platformKeyAssertionRequest.prf = request.extensions?.prf?.eval.map { eval in
-        let first = Data(base64URLEncoded: eval.first)!
-        let second = eval.second.flatMap { Data(base64URLEncoded: $0) }
+      platformKeyAssertionRequest.prf = try request.extensions?.prf?.eval.map { eval in
+        guard let first = Data(base64URLEncoded: eval.first) else {
+          throw AppError.invalidPrfFirstValueException
+        }
+        let second = try eval.second.map { secondValue in
+          guard let decoded = Data(base64URLEncoded: secondValue) else {
+            throw AppError.invalidPrfSecondValueException
+          }
+          return decoded
+        }
         return .inputValues(ASAuthorizationPublicKeyCredentialPRFAssertionInput.InputValues(saltInput1: first, saltInput2: second))
       }
   }


### PR DESCRIPTION
* Added `return` after `handler.onFailure`
* Added explicit check for `Missing relying party ID`
* Added explicit check for non-null data for base64URL encoded data

fixes: https://github.com/ExodusMovement/exodus-mobile/issues/32373

@joshua-rogers-exodus what about Android w.r.t, we don't parse it there, just pass it on to the underlying library, which I *assume* checks it as well?
* Added explicit check for `Missing relying party ID`
* Added explicit check for non-null data for base64URL encoded data

cc @peterferguson happy to help upstream any of these changes if interested, 