### PR TITLE
fix: don't require biometry

### DIFF
--- a/ios/PasskeyExceptions.swift
+++ b/ios/PasskeyExceptions.swift
@@ -4,7 +4,7 @@ enum AppError: Error {
   case notSupportedException
   case notConfiguredException
   case pendingPasskeyRequestException
-  case biometricException
+  case deviceAuthenticationException
   case userCancelledException
   case invalidChallengeException
   case missingUserIdException
@@ -27,8 +27,8 @@ extension AppError: LocalizedError {
         return "NOT_SUPPORTED: Passkeys are not supported on this iOS version. Please use iOS 15 or above."
       case .pendingPasskeyRequestException:
         return "There is already a pending passkey request"
-      case .biometricException:
-        return "NOT_SUPPORTED: Biometrics must be enabled"
+      case .deviceAuthenticationException:
+        return "NOT_SUPPORTED: Device authentication is not available. Enable passcode (or biometrics)."
       case .userCancelledException:
         return "USER_CANCELLED"
       case .invalidChallengeException:

--- a/ios/ReactNativePasskeys.swift
+++ b/ios/ReactNativePasskeys.swift
@@ -49,8 +49,9 @@ class ReactNativePasskeys: NSObject, PasskeyResultHandler {
       throw AppError.pendingPasskeyRequestException
     }
 
-    if LAContext().biometricType == .none {
-      throw AppError.biometricException
+    var error: NSError?
+    if !LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+      throw AppError.deviceAuthenticationException
     }
 
     return true


### PR DESCRIPTION
allow passkeys creation if passcode enabled without biometry