### PR TITLE
chore: upgrade to 0.3.3-exodus.9 for RN 0.85

### DIFF
--- a/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
+++ b/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
@@ -65,7 +65,7 @@ class ReactNativePasskeysModule internal constructor(private val context: ReactA
     mainScope.launch {
       try {
         val result =
-                currentActivity?.let {
+                reactApplicationContext.currentActivity?.let {
                   credentialManager.createCredential(it, createPublicKeyCredentialRequest)
                 }
         val response =
@@ -94,7 +94,7 @@ class ReactNativePasskeysModule internal constructor(private val context: ReactA
     mainScope.launch {
       try {
         val result =
-                currentActivity?.let { credentialManager.getCredential(it, getCredentialRequest) }
+                reactApplicationContext.currentActivity?.let { credentialManager.getCredential(it, getCredentialRequest) }
         val response =
                 result?.credential?.data?.getString(
                         "androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-passkeys",
-  "version": "0.3.3-exodus.8",
+  "version": "0.3.3-exodus.9",
   "description": "A library for using (webauthn) passkeys on iOS, Android & web with a single api",
   "main": "build/index.js",
   "packageManager": "yarn@4.9.4",


### PR DESCRIPTION
## Summary

Version bump to `0.3.3-exodus.9` for RN 0.85 upgrade.
Part of [ExodusMovement/exodus-mobile#38221](https://github.com/ExodusMovement/exodus-mobile/issues/38221).

## Audit

<details>
<summary>Audit Report</summary>

# Step 4: Security Audit for react-native-passkeys
Date: 2026-04-23 11:45 UTC
Scan scope: Diff: e7ee0230f75b..exodus-0.3.3-rn85
Added lines scanned: 3041

## Summary
| Severity | Findings |
|----------|----------|
| CRITICAL | 0 |
| HIGH | 23 |
| MEDIUM | 0 |

## Detailed Findings
### HIGH: Hardcoded URL (21 occurrences)
```
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+# https://docs.fastlane.tools/best-practices/source-control/
+source 'https://rubygems.org'
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
```

### HIGH: Binary blob reference (2 occurrences)
```
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
```

</details>

## Patches

<details>
<summary>Patch Analysis</summary>

# Step 1: Patch Analysis for react-native-passkeys
Date: 2026-04-23 11:45 UTC

## Summary
- Fork branch: `exodus-0.3.3`
- Merge-base: `e7ee0230f75b`
- Exodus commits: **50**

## Commit Log
```
bc87106 0.3.3-exodus.8
4e71956 fix: missing autofill for iOS (#31)
4865548 chore: release 0.3.3-exodus.7
d0de21b fix: bind native module methods explicitly for new architecture compatibility
2880b4b fix: deserialize JSON before returning (#30)
ce46b75 Merge pull request #29 from ExodusMovement/egor/chore/exodus-5
d3dabf2 chore: bump exodus.5
a1b28cf Merge pull request #28 from ExodusMovement/egor/fix/biometry
52e83bb fix: don't require biometry
22ce4e8 chore: release 0.3.3-exodus.4
c267ba7 chore: release 0.3.3-exodus.3
dcdb493 feat: harden passkeys implementation (#27)
587b76e chore: release 0.3.3-exodus.2
437bd5a feat: add isSupported and properly expose on iOS (#26)
1abaf73 chore: release 0.3.3-exodus.1
6dde8d3 fix: serialize data to base64url
4f087bb fix: support checking for PRF support without deriving a key (#25)
5c66902 feat: add iOS PRF support  (#24)
ae38adc feat: sync upstream v0.3.3 (#23)
719bcf7 Publish 0.3.8 (#22)
b4354dd fix: publish only needed files (#21)
9067a76 Publish 0.3.6
5d81ddf fix: reviews (#20)
281ac36 0.3.5 fix: use com.google.android.gms:play-services-auth:21.1.1 (#19)
78a5c8a v0.3.4 fix(android): bump androidx.credentials:credentials dep (#18)
cb6fa82 fix(android): add proguard-rules.pro (#17)
8b66bb2 fix(android): remove unused gradle files (#16)
273381c fix(Android): publish only needed files (#15)
0c91fce fix(Android): add get_login_creds (#14)
2054373 feat: remove expo from Android module (#6)
b8b590c bump gson dep (#8)
eb8ec44 Merge pull request #7 from ExodusMovement/guten/ios-rm-flag
aa5aa47 fix(iOS): remove -Wno-comma -Wno-shorten-64-to-32 flags
3570f84 Publish: 0.2.5
4de0947 Publish: 0.2.4
26ecb02 Merge pull request #4 from ExodusMovement/guten/fix
7d084c2 fix: android build remove publish and update tsconfig
139fc70 Merge pull request #3 from ExodusMovement/guten/0.2.3
710adb0 fix files field
745a058 Publish: 0.2.3
fcd32f6 Merge pull request #2 from ExodusMovement/guten/cleanup
402c617 Merge pull request #1 from ExodusMovement/egor/feat/remove-expo
6e9f21e remove unused fields
054ba00 fix: publish only needed files
fd31798 update annotations
fe83908 change name
b085ff3 change name
95a5cea change version name
c173e6c move podspec in root
f33cdcf feat: remove expo from IOS module.
```

## Categorized Patches
```
OTHER: 0.3.3-exodus.8
BUG_FIX: fix: missing autofill for iOS (#31)
PACKAGING: chore: release 0.3.3-exodus.7
BUG_FIX: fix: bind native module methods explicitly for new architecture compatibility
BUG_FIX: fix: deserialize JSON before returning (#30)
OTHER: Merge pull request #29 from ExodusMovement/egor/chore/exodus-5
PACKAGING: chore: bump exodus.5
OTHER: Merge pull request #28 from ExodusMovement/egor/fix/biometry
BUG_FIX: fix: don't require biometry
PACKAGING: chore: release 0.3.3-exodus.4
PACKAGING: chore: release 0.3.3-exodus.3
SECURITY: feat: harden passkeys implementation (#27)
PACKAGING: chore: release 0.3.3-exodus.2
FEATURE: feat: add isSupported and properly expose on iOS (#26)
PACKAGING: chore: release 0.3.3-exodus.1
BUG_FIX: fix: serialize data to base64url
BUG_FIX: fix: support checking for PRF support without deriving a key (#25)
FEATURE: feat: add iOS PRF support  (#24)
FEATURE: feat: sync upstream v0.3.3 (#23)
OTHER: Publish 0.3.8 (#22)
BUG_FIX: fix: publish only needed files (#21)
OTHER: Publish 0.3.6
BUG_FIX: fix: reviews (#20)
OTHER: 0.3.5 fix: use com.google.android.gms:play-services-auth:21.1.1 (#19)
OTHER: v0.3.4 fix(android): bump androidx.credentials:credentials dep (#18)
BUG_FIX: fix(android): add proguard-rules.pro (#17)
BUG_FIX: fix(android): remove unused gradle files (#16)
BUG_FIX: fix(Android): publish only needed files (#15)
BUG_FIX: fix(Android): add get_login_creds (#14)
FEATURE: feat: remove expo from Android module (#6)
OTHER: bump gson dep (#8)
OTHER: Merge pull request #7 from ExodusMovement/guten/ios-rm-flag
BUG_FIX: fix(iOS): remove -Wno-comma -Wno-shorten-64-to-32 flags
OTHER: Publish: 0.2.5
OTHER: Publish: 0.2.4
OTHER: Merge pull request #4 from ExodusMovement/guten/fix
BUG_FIX: fix: android build remove publish and update tsconfig
OTHER: Merge pull request #3 from ExodusMovement/guten/0.2.3
BUG_FIX: fix files field
OTHER: Publish: 0.2.3
OTHER: Merge pull request #2 from ExodusMovement/guten/cleanup
OTHER: Merge pull request #1 from ExodusMovement/egor/feat/remove-expo
OTHER: remove unused fields
BUG_FIX: fix: publish only needed files
OTHER: update annotations
OTHER: change name
OTHER: change name
OTHER: change version name
OTHER: move podspec in root
FEATURE: feat: remove expo from IOS module.
```

## Security-Critical Patches
SECURITY: feat: harden passkeys implementation (#27)

</details>

## Test Plan

- [ ] Update `src/package.json` in exodus-mobile-upgrade worktree
- [ ] `yarn ios:base` builds
- [ ] `yarn android:base` builds
- [ ] Functional test